### PR TITLE
Overlay

### DIFF
--- a/client/src/components/App.jsx
+++ b/client/src/components/App.jsx
@@ -95,7 +95,7 @@ class App extends React.Component {
         </div>
 
         <div>
-          <input id={styles.calendarSelect} defaultValue={this.dateString} value={this.state.date} onClick={this.displayCalendar} readOnly/>
+          <input id={styles.calendarSelect} defaultValue={this.dateString} value={this.state.date} onClick={this.displayCalendar} readOnly />
         </div>
 
         <div id={styles.selectRow}>
@@ -114,7 +114,7 @@ class App extends React.Component {
         </div>
 
         <div>
-          {this.state.displayCalendar ? <Calendar currentDate={this.state.dateUTC} handleDayClick={this.handleDayClick} /> : null}
+          {this.state.displayCalendar ? <Calendar selectedDate={this.state.dateUTC} openHours={sampleData.openHours} handleDayClick={this.handleDayClick} /> : null}
         </div>
 
       </div>

--- a/client/src/components/App.jsx
+++ b/client/src/components/App.jsx
@@ -15,6 +15,7 @@ class App extends React.Component {
       time: '7:00 pm',
       partySize: '2 people',
       displayCalendar: false,
+      dateUTC: new Date(),
     };
 
     this.date = new Date();
@@ -30,6 +31,10 @@ class App extends React.Component {
 
   componentDidMount() {
     // this.getData();
+    this.setState({
+      dateUTC: new Date(),
+      date: this.date.toDateString(),
+    });
   }
 
   getData() {
@@ -71,6 +76,7 @@ class App extends React.Component {
     this.setState({
       date: dateString,
       displayCalendar: false,
+      dateUTC: dateUTC,
     });
   }
 
@@ -108,7 +114,7 @@ class App extends React.Component {
         </div>
 
         <div>
-          {this.state.displayCalendar ? <Calendar currentDate={this.date} handleDayClick={this.handleDayClick} /> : null}
+          {this.state.displayCalendar ? <Calendar currentDate={this.state.dateUTC} handleDayClick={this.handleDayClick} /> : null}
         </div>
 
       </div>

--- a/client/src/components/App.jsx
+++ b/client/src/components/App.jsx
@@ -103,7 +103,7 @@ class App extends React.Component {
         </div>
 
         <div>
-          {this.state.displayCalendar ? <Calendar handleDayClick={this.handleDayClick} /> : null}
+          {this.state.displayCalendar ? <Calendar currentDate={this.date} handleDayClick={this.handleDayClick} /> : null}
         </div>
 
       </div>

--- a/client/src/components/App.jsx
+++ b/client/src/components/App.jsx
@@ -57,6 +57,7 @@ class App extends React.Component {
   }
 
   handleDayClick(event) {
+    console.log(event);
     let day = event.target.innerText;
     if (day < 10) {
       day = `0${day}`;

--- a/client/src/components/App.jsx
+++ b/client/src/components/App.jsx
@@ -61,6 +61,10 @@ class App extends React.Component {
     });
   }
 
+  onMouseDown(event) {
+    event.target.style.background = '#be2020';
+  }
+
   handleDayClick(event) {
     let month = Number(event.target.getAttribute('month')) + 1;
     const year = event.target.getAttribute('year');
@@ -110,7 +114,7 @@ class App extends React.Component {
         </div>
 
         <div>
-          <button id={styles.button}>Find a Table</button>
+          <button id={styles.button} onMouseDown={this.onMouseDown}>Find a Table</button>
         </div>
 
         <div>

--- a/client/src/components/App.jsx
+++ b/client/src/components/App.jsx
@@ -57,12 +57,16 @@ class App extends React.Component {
   }
 
   handleDayClick(event) {
-    console.log(event);
-    let day = event.target.innerText;
+    let month = Number(event.target.getAttribute('month')) + 1;
+    const year = event.target.getAttribute('year');
+    let day = event.target.getAttribute('day');
     if (day < 10) {
       day = `0${day}`;
     }
-    const dateUTC = new Date(`2020-02-${day}T10:20:30Z`);
+    if (month < 10) {
+      month = `0${month}`;
+    }
+    const dateUTC = new Date(`${year}-${month}-${day}T10:20:30Z`);
     const dateString = dateUTC.toDateString();
     this.setState({
       date: dateString,
@@ -85,7 +89,7 @@ class App extends React.Component {
         </div>
 
         <div>
-          <input id={styles.calendarSelect} defaultValue={this.dateString} value={this.state.date} onClick={this.displayCalendar} />
+          <input id={styles.calendarSelect} defaultValue={this.dateString} value={this.state.date} onClick={this.displayCalendar} readOnly/>
         </div>
 
         <div id={styles.selectRow}>

--- a/client/src/components/App.jsx
+++ b/client/src/components/App.jsx
@@ -114,7 +114,7 @@ class App extends React.Component {
       </div>
 
     );
-  };
+  }
 }
 
 export default App;

--- a/client/src/components/Calendar.jsx
+++ b/client/src/components/Calendar.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable jsx-a11y/no-noninteractive-element-interactions */
 /* eslint-disable jsx-a11y/click-events-have-key-events */
 import React from 'react';
 import styles from './styles.css';
@@ -39,7 +40,18 @@ class Calendar extends React.Component {
           daysInRow.push(greyCell);
           date += 1;
         } else {
-          const filledCell = <td className={styles.filledCell} key={`current${date}`} onClick={this.props.handleDayClick}>{date}</td>;
+          const filledCell = (
+            <td
+              className={styles.filledCell}
+              key={`current${date}`}
+              month={month}
+              year={year}
+              day={date}
+              onClick={this.props.handleDayClick}
+            >
+              {date}
+            </td>
+          );
           daysInRow.push(filledCell);
           date += 1;
         }
@@ -84,7 +96,11 @@ class Calendar extends React.Component {
             <div className={styles.leftArrow} onClick={this.handleLeftArrowClick.bind(this)}><i className="fas fa-angle-left" /></div>
           </div>
           <div className={styles.monthYearContainer}>
-            <div className={styles.monthYear}>{this.monthNames[this.state.month]} {this.state.year}</div>
+            <div className={styles.monthYear}>
+              {this.monthNames[this.state.month]}
+              {' '}
+              {this.state.year}
+            </div>
           </div>
           <div className={styles.arrowButton}>
             <div className={styles.rightArrow} onClick={this.handleRightArrowClick.bind(this)}><i className="fas fa-angle-right" /></div>

--- a/client/src/components/Calendar.jsx
+++ b/client/src/components/Calendar.jsx
@@ -30,6 +30,11 @@ class Calendar extends React.Component {
     const numOfDaysPrev = 32 - new Date(year, month - 1, 32).getDate();
     const lastDayofPrevMonth = new Date(year, month - 1, numOfDaysPrev).getDay();
 
+    const currentDate = new Date();
+    const currentDay = currentDate.getDate();
+    const currentMonth = Number(currentDate.getMonth());
+    const currentYear = currentDate.getFullYear();
+
     let date = 1;
     const calendarRows = [];
 
@@ -48,6 +53,9 @@ class Calendar extends React.Component {
           date += 1;
         } else {
           if (this.closedDaysIndex.includes(i)) {
+            const greyCell = <td className={styles.greyCell} key={`current${date}`}>{date}</td>;
+            daysInRow.push(greyCell);
+          } else if (month === currentMonth && date < currentDay) {
             const greyCell = <td className={styles.greyCell} key={`current${date}`}>{date}</td>;
             daysInRow.push(greyCell);
           } else {

--- a/client/src/components/Calendar.jsx
+++ b/client/src/components/Calendar.jsx
@@ -15,12 +15,18 @@ class Calendar extends React.Component {
     this.monthNames = ['January', 'February', 'March', 'April', 'May', 'June', 'July',
       'August', 'September', 'October', 'November', 'December'];
     this.dayNames = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
+
     this.closedDaysIndex = [];
     for (let i = 0; i < this.dayNames.length; i += 1) {
       if (this.props.openHours[this.dayNames[i]].length === 0) {
         this.closedDaysIndex.push(i);
       }
     }
+
+    this.currentDate = new Date();
+    this.currentDay = this.currentDate.getDate();
+    this.currentMonth = Number(this.currentDate.getMonth());
+    this.currentYear = this.currentDate.getFullYear(); 
   }
 
   generateCalendar(year, month) {
@@ -29,11 +35,6 @@ class Calendar extends React.Component {
 
     const numOfDaysPrev = 32 - new Date(year, month - 1, 32).getDate();
     const lastDayofPrevMonth = new Date(year, month - 1, numOfDaysPrev).getDay();
-
-    const currentDate = new Date();
-    const currentDay = currentDate.getDate();
-    const currentMonth = Number(currentDate.getMonth());
-    const currentYear = currentDate.getFullYear();
 
     let date = 1;
     const calendarRows = [];
@@ -66,7 +67,7 @@ class Calendar extends React.Component {
           if (this.closedDaysIndex.includes(i)) {
             const greyCell = <td className={styles.greyCell} key={`current${date}`}>{date}</td>;
             daysInRow.push(greyCell);
-          } else if (month === currentMonth && date < currentDay) {
+          } else if (month === this.currentMonth && date < this.currentDay) {
             const greyCell = <td className={styles.greyCell} key={`current${date}`}>{date}</td>;
             daysInRow.push(greyCell);
           } else {
@@ -128,7 +129,9 @@ class Calendar extends React.Component {
       <div className={styles.calendar}>
         <div className={styles.captionRow}>
           <div className={styles.arrowButton}>
-            <div className={styles.leftArrow} onClick={this.handleLeftArrowClick.bind(this)}><i className="fas fa-angle-left" /></div>
+            {(this.state.year >= this.currentYear && this.state.month > this.currentMonth)
+              ? <div className={styles.leftArrow} onClick={this.handleLeftArrowClick.bind(this)}><i className="fas fa-angle-left" /></div>
+              : <div /> }
           </div>
           <div className={styles.monthYearContainer}>
             <div className={styles.monthYear}>

--- a/client/src/components/Calendar.jsx
+++ b/client/src/components/Calendar.jsx
@@ -45,12 +45,28 @@ class Calendar extends React.Component {
       for (let i = 0; i < 7; i += 1) {
         if (r === 0 && i < firstDayOfMonth) {
           const prevDate = numOfDaysPrev - (lastDayofPrevMonth - i);
-          const greyCell = <td className={styles.greyCell} key={`prev${prevDate}`}>{prevDate}</td>;
-          daysInRow.push(greyCell);
+          if (month === this.currentMonth || this.closedDaysIndex.includes(i)) {
+            const greyCell = <td className={styles.greyCell} key={`prev${prevDate}`}>{prevDate}</td>;
+            daysInRow.push(greyCell);
+          } else {
+            const futureGreyCell = (
+              <td
+                className={styles.futureGreyCell}
+                key={`next${prevDate}`}
+                month={month}
+                year={year}
+                day={prevDate}
+                onClick={this.props.handleDayClick}
+              >
+                {prevDate}
+              </td>
+            );
+            daysInRow.push(futureGreyCell);
+          }
         } else if (date > numOfDays) {
           const nextDate = date - numOfDays;
           const futureGreyCell = (
-            <td 
+            <td
               className={styles.futureGreyCell}
               key={`next${nextDate}`}
               month={month}

--- a/client/src/components/Calendar.jsx
+++ b/client/src/components/Calendar.jsx
@@ -121,53 +121,18 @@ class Calendar extends React.Component {
           <tbody className={styles.tbody} id="tbody">
             <tr>
               {calendarPage[0].map((day) => day)}
-              {/* <td className={styles.greyCell}>30</td>
-              <td className={styles.filledCell} onClick={this.props.handleDayClick}>1</td>
-              <td className={styles.filledCell} onClick={this.props.handleDayClick}>2</td>
-              <td className={styles.filledCell} onClick={this.props.handleDayClick}>3</td>
-              <td className={styles.filledCell} onClick={this.props.handleDayClick}>4</td>
-              <td className={styles.filledCell} onClick={this.props.handleDayClick}>5</td>
-              <td className={styles.filledCell} onClick={this.props.handleDayClick}>6</td> */}
             </tr>
             <tr>
               {calendarPage[1].map((day) => day)}
-              {/* <td className={styles.filledCell} onClick={this.props.handleDayClick}>7</td>
-              <td className={styles.filledCell} onClick={this.props.handleDayClick}>8</td>
-              <td className={styles.filledCell} onClick={this.props.handleDayClick}>9</td>
-              <td className={styles.filledCell} onClick={this.props.handleDayClick}>10</td>
-              <td className={styles.filledCell} onClick={this.props.handleDayClick}>11</td>
-              <td className={styles.filledCell} onClick={this.props.handleDayClick}>12</td>
-              <td className={styles.filledCell} onClick={this.props.handleDayClick}>13</td> */}
             </tr>
             <tr>
               {calendarPage[2].map((day) => day)}
-              {/* <td className={styles.filledCell} onClick={this.props.handleDayClick}>14</td>
-              <td className={styles.filledCell} onClick={this.props.handleDayClick}>15</td>
-              <td className={styles.filledCell} onClick={this.props.handleDayClick}>16</td>
-              <td className={styles.filledCell} onClick={this.props.handleDayClick}>17</td>
-              <td className={styles.filledCell} onClick={this.props.handleDayClick}>18</td>
-              <td className={styles.filledCell} onClick={this.props.handleDayClick}>19</td>
-              <td className={styles.filledCell} onClick={this.props.handleDayClick}>20</td> */}
             </tr>
             <tr>
               {calendarPage[3].map((day) => day)}
-              {/* <td className={styles.filledCell} onClick={this.props.handleDayClick}>21</td>
-              <td className={styles.filledCell} onClick={this.props.handleDayClick}>22</td>
-              <td className={styles.filledCell} onClick={this.props.handleDayClick}>23</td>
-              <td className={styles.filledCell} onClick={this.props.handleDayClick}>24</td>
-              <td className={styles.filledCell} onClick={this.props.handleDayClick}>25</td>
-              <td className={styles.filledCell} onClick={this.props.handleDayClick}>26</td>
-              <td className={styles.filledCell} onClick={this.props.handleDayClick}>27</td> */}
             </tr>
             <tr>
               {calendarPage[4].map((day) => day)}
-              {/* <td className={styles.filledCell} onClick={this.props.handleDayClick}>28</td>
-              <td className={styles.filledCell} onClick={this.props.handleDayClick}>29</td>
-              <td className={styles.greyCell}>1</td>
-              <td className={styles.greyCell}>2</td>
-              <td className={styles.greyCell}>3</td>
-              <td className={styles.greyCell}>4</td>
-              <td className={styles.greyCell}>5</td> */}
             </tr>
           </tbody>
         </table>

--- a/client/src/components/Calendar.jsx
+++ b/client/src/components/Calendar.jsx
@@ -49,19 +49,45 @@ class Calendar extends React.Component {
     return calendarRows;
   }
 
+  handleLeftArrowClick(event) {
+    if (this.state.month !== 0) {
+      this.setState({
+        month: this.state.month - 1,
+      });
+    } else {
+      this.setState({
+        year: this.state.year - 1,
+        month: 11,
+      });
+    }
+  }
+
+  handleRightArrowClick(event) {
+    if (this.state.month !== 11) {
+      this.setState({
+        month: this.state.month + 1,
+      });
+    } else {
+      this.setState({
+        year: this.state.year + 1,
+        month: 0,
+      });
+    }
+  }
+
   render() {
     const calendarPage = this.generateCalendar(this.state.year, this.state.month);
     return (
       <div className={styles.calendar}>
         <div className={styles.captionRow}>
           <div className={styles.arrowButton}>
-            <div className={styles.leftArrow}><i className="fas fa-angle-left" /></div>
+            <div className={styles.leftArrow} onClick={this.handleLeftArrowClick.bind(this)}><i className="fas fa-angle-left" /></div>
           </div>
           <div className={styles.monthYearContainer}>
             <div className={styles.monthYear}>{this.monthNames[this.state.month]} {this.state.year}</div>
           </div>
           <div className={styles.arrowButton}>
-            <div className={styles.rightArrow}><i className="fas fa-angle-right" /></div>
+            <div className={styles.rightArrow} onClick={this.handleRightArrowClick.bind(this)}><i className="fas fa-angle-right" /></div>
           </div>
         </div>
         <table>

--- a/client/src/components/Calendar.jsx
+++ b/client/src/components/Calendar.jsx
@@ -8,12 +8,19 @@ class Calendar extends React.Component {
     super(props);
 
     this.state = {
-      year: this.props.currentDate.getFullYear(),
-      month: this.props.currentDate.getMonth(),
+      year: this.props.selectedDate.getFullYear(),
+      month: this.props.selectedDate.getMonth(),
     };
 
     this.monthNames = ['January', 'February', 'March', 'April', 'May', 'June', 'July',
       'August', 'September', 'October', 'November', 'December'];
+    this.dayNames = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
+    this.closedDaysIndex = [];
+    for (let i = 0; i < this.dayNames.length; i += 1) {
+      if (this.props.openHours[this.dayNames[i]].length === 0) {
+        this.closedDaysIndex.push(i);
+      }
+    }
   }
 
   generateCalendar(year, month) {
@@ -40,19 +47,28 @@ class Calendar extends React.Component {
           daysInRow.push(greyCell);
           date += 1;
         } else {
-          const filledCell = (
-            <td
-              className={styles.filledCell}
-              key={`current${date}`}
-              month={month}
-              year={year}
-              day={date}
-              onClick={this.props.handleDayClick}
-            >
-              {date}
-            </td>
-          );
-          daysInRow.push(filledCell);
+          if (this.closedDaysIndex.includes(i)) {
+            const greyCell = <td className={styles.greyCell} key={`current${date}`}>{date}</td>;
+            daysInRow.push(greyCell);
+          } else {
+            const day = date < 10 ? `0${date}` : date;
+            let calendarMonth = Number(month) + 1;
+            calendarMonth = calendarMonth < 10 ? `0${calendarMonth}` : calendarMonth;
+            const dateString = (new Date(`${year}-${calendarMonth}-${day}T10:20:30Z`)).toDateString();
+            const filledCell = (
+              <td
+                className={dateString === this.props.selectedDate.toDateString() ? styles.selectedCell : styles.filledCell}
+                key={`current${date}`}
+                month={month}
+                year={year}
+                day={date}
+                onClick={this.props.handleDayClick}
+              >
+                {date}
+              </td>
+            );
+            daysInRow.push(filledCell);
+          }
           date += 1;
         }
       }

--- a/client/src/components/Calendar.jsx
+++ b/client/src/components/Calendar.jsx
@@ -48,8 +48,19 @@ class Calendar extends React.Component {
           daysInRow.push(greyCell);
         } else if (date > numOfDays) {
           const nextDate = date - numOfDays;
-          const greyCell = <td className={styles.greyCell} key={`next${nextDate}`}>{nextDate}</td>;
-          daysInRow.push(greyCell);
+          const futureGreyCell = (
+            <td 
+              className={styles.futureGreyCell}
+              key={`next${nextDate}`}
+              month={month}
+              year={year}
+              day={nextDate}
+              onClick={this.props.handleDayClick}
+            >
+              {nextDate}
+            </td>
+          );
+          daysInRow.push(futureGreyCell);
           date += 1;
         } else {
           if (this.closedDaysIndex.includes(i)) {

--- a/client/src/components/Calendar.jsx
+++ b/client/src/components/Calendar.jsx
@@ -7,26 +7,65 @@ class Calendar extends React.Component {
     super(props);
 
     this.state = {
-      month: 0,
+      year: this.props.currentDate.getFullYear(),
+      month: this.props.currentDate.getMonth(),
     };
+
+    this.monthNames = ['January', 'February', 'March', 'April', 'May', 'June', 'July',
+      'August', 'September', 'October', 'November', 'December'];
+  }
+
+  generateCalendar(year, month) {
+    const firstDayOfMonth = new Date(year, month).getDay();
+    const numOfDays = 32 - new Date(year, month, 32).getDate();
+
+    const numOfDaysPrev = 32 - new Date(year, month - 1, 32).getDate();
+    const lastDayofPrevMonth = new Date(year, month - 1, numOfDaysPrev).getDay();
+
+    let date = 1;
+    const calendarRows = [];
+
+    for (let r = 0; r < 5; r += 1) {
+      const daysInRow = [];
+
+      for (let i = 0; i < 7; i += 1) {
+        if (r === 0 && i < firstDayOfMonth) {
+          const prevDate = numOfDaysPrev - (lastDayofPrevMonth - i);
+          const greyCell = <td className={styles.greyCell} key={`prev${prevDate}`}>{prevDate}</td>;
+          daysInRow.push(greyCell);
+        } else if (date > numOfDays) {
+          const nextDate = date - numOfDays;
+          const greyCell = <td className={styles.greyCell} key={`next${nextDate}`}>{nextDate}</td>;
+          daysInRow.push(greyCell);
+          date += 1;
+        } else {
+          const filledCell = <td className={styles.filledCell} key={`current${date}`} onClick={this.props.handleDayClick}>{date}</td>;
+          daysInRow.push(filledCell);
+          date += 1;
+        }
+      }
+      calendarRows.push(daysInRow);
+    }
+    return calendarRows;
   }
 
   render() {
+    const calendarPage = this.generateCalendar(this.state.year, this.state.month);
     return (
       <div className={styles.calendar}>
         <div className={styles.captionRow}>
           <div className={styles.arrowButton}>
-            <div id={styles.leftArrow}><i className="fas fa-angle-left" /></div>
+            <div className={styles.leftArrow}><i className="fas fa-angle-left" /></div>
           </div>
-          <div id={styles.monthYearContainer}>
-            <div id={styles.monthYear}>Feb 2020</div>
+          <div className={styles.monthYearContainer}>
+            <div className={styles.monthYear}>{this.monthNames[this.state.month]} {this.state.year}</div>
           </div>
           <div className={styles.arrowButton}>
-            <div id={styles.rightArrow}><i className="fas fa-angle-right" /></div>
+            <div className={styles.rightArrow}><i className="fas fa-angle-right" /></div>
           </div>
         </div>
         <table>
-          <thead id={styles.tableHead}>
+          <thead className={styles.tableHead}>
             <tr>
               <td className={styles.weekday}>Su</td>
               <td className={styles.weekday}>Mo</td>
@@ -37,53 +76,57 @@ class Calendar extends React.Component {
               <td className={styles.weekday}>Sa</td>
             </tr>
           </thead>
-          <tbody id={styles.tbody}>
+          <tbody className={styles.tbody} id="tbody">
             <tr>
-              <td className={styles.greyCell}>30</td>
+              {calendarPage[0].map((day) => day)}
+              {/* <td className={styles.greyCell}>30</td>
               <td className={styles.filledCell} onClick={this.props.handleDayClick}>1</td>
               <td className={styles.filledCell} onClick={this.props.handleDayClick}>2</td>
               <td className={styles.filledCell} onClick={this.props.handleDayClick}>3</td>
               <td className={styles.filledCell} onClick={this.props.handleDayClick}>4</td>
               <td className={styles.filledCell} onClick={this.props.handleDayClick}>5</td>
-              <td className={styles.filledCell} onClick={this.props.handleDayClick}>6</td>
+              <td className={styles.filledCell} onClick={this.props.handleDayClick}>6</td> */}
             </tr>
             <tr>
-              <td className={styles.filledCell} onClick={this.props.handleDayClick}>7</td>
+              {calendarPage[1].map((day) => day)}
+              {/* <td className={styles.filledCell} onClick={this.props.handleDayClick}>7</td>
               <td className={styles.filledCell} onClick={this.props.handleDayClick}>8</td>
               <td className={styles.filledCell} onClick={this.props.handleDayClick}>9</td>
               <td className={styles.filledCell} onClick={this.props.handleDayClick}>10</td>
               <td className={styles.filledCell} onClick={this.props.handleDayClick}>11</td>
               <td className={styles.filledCell} onClick={this.props.handleDayClick}>12</td>
-              <td className={styles.filledCell} onClick={this.props.handleDayClick}>13</td>
+              <td className={styles.filledCell} onClick={this.props.handleDayClick}>13</td> */}
             </tr>
             <tr>
-              <td className={styles.filledCell} onClick={this.props.handleDayClick}>14</td>
+              {calendarPage[2].map((day) => day)}
+              {/* <td className={styles.filledCell} onClick={this.props.handleDayClick}>14</td>
               <td className={styles.filledCell} onClick={this.props.handleDayClick}>15</td>
               <td className={styles.filledCell} onClick={this.props.handleDayClick}>16</td>
               <td className={styles.filledCell} onClick={this.props.handleDayClick}>17</td>
               <td className={styles.filledCell} onClick={this.props.handleDayClick}>18</td>
               <td className={styles.filledCell} onClick={this.props.handleDayClick}>19</td>
-              <td className={styles.filledCell} onClick={this.props.handleDayClick}>20</td>
+              <td className={styles.filledCell} onClick={this.props.handleDayClick}>20</td> */}
             </tr>
             <tr>
-              <td className={styles.filledCell} onClick={this.props.handleDayClick}>21</td>
+              {calendarPage[3].map((day) => day)}
+              {/* <td className={styles.filledCell} onClick={this.props.handleDayClick}>21</td>
               <td className={styles.filledCell} onClick={this.props.handleDayClick}>22</td>
               <td className={styles.filledCell} onClick={this.props.handleDayClick}>23</td>
               <td className={styles.filledCell} onClick={this.props.handleDayClick}>24</td>
               <td className={styles.filledCell} onClick={this.props.handleDayClick}>25</td>
               <td className={styles.filledCell} onClick={this.props.handleDayClick}>26</td>
-              <td className={styles.filledCell} onClick={this.props.handleDayClick}>27</td>
+              <td className={styles.filledCell} onClick={this.props.handleDayClick}>27</td> */}
             </tr>
             <tr>
-              <td className={styles.filledCell} onClick={this.props.handleDayClick}>28</td>
+              {calendarPage[4].map((day) => day)}
+              {/* <td className={styles.filledCell} onClick={this.props.handleDayClick}>28</td>
               <td className={styles.filledCell} onClick={this.props.handleDayClick}>29</td>
               <td className={styles.greyCell}>1</td>
               <td className={styles.greyCell}>2</td>
               <td className={styles.greyCell}>3</td>
               <td className={styles.greyCell}>4</td>
-              <td className={styles.greyCell}>5</td>
+              <td className={styles.greyCell}>5</td> */}
             </tr>
-
           </tbody>
         </table>
       </div>

--- a/client/src/components/styles.css
+++ b/client/src/components/styles.css
@@ -74,6 +74,7 @@
   padding: 8px 19px 9px;
   border-radius: 3px;
   color: #fff;
+  z-index: 5;
 }
 
 .calendar {
@@ -81,7 +82,12 @@
   flex-direction: column;
   border: 2px solid rgb(230, 230, 230);
   border-radius: 4px;
-  padding: 10px
+  padding: 10px;
+  margin-top: -75px;
+  background-color: white;
+  z-index: 10;
+  position: relative;
+  top: 0;
 }
 
 .captionRow {

--- a/client/src/components/styles.css
+++ b/client/src/components/styles.css
@@ -166,3 +166,11 @@ td {
   justify-content: center;
   color: rgba(51,51,51,.2);
 }
+
+.selectedCell {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  background-color: #d32323;
+  color: #fff;
+}

--- a/client/src/components/styles.css
+++ b/client/src/components/styles.css
@@ -96,13 +96,13 @@
   justify-content: center;
 }
 
-#monthYearContainer {
+.monthYearContainer {
   display: flex;
   flex-direction: column;
   justify-content: center;
 }
 
-#monthYear {
+.monthYear {
   font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
   font-weight: 600;
   font-size: .925rem;
@@ -124,7 +124,7 @@
   margin-bottom: 5px;
 }
 
-#tbody tr td {
+.tbody tr td {
   text-align: center;
   border: 1px solid rgb(230, 230, 230);
   width: calc(100% / 7);

--- a/client/src/components/styles.css
+++ b/client/src/components/styles.css
@@ -167,6 +167,18 @@ td {
   color: rgba(51,51,51,.2);
 }
 
+.futureGreyCell {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  color: rgba(51,51,51,.2);
+}
+
+.futureGreyCell:hover {
+  background-color: rgb(227, 240, 245);
+  cursor: pointer;
+}
+
 .selectedCell {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
Add a ton of calendar functionality, including:
 - now appears as an overlay rather than below the component
 - do not allow user to scroll to months prior to current month in time (back arrow is removed on current month's calendar page)
 - make past days unclickable
 - check for days the business is closed and makes them unclickable
 - selected day is highlighted in red on calendar page
 - future days are all clickable as long as the business is open (but are greyed out if not corresponding that particular calendar page's month)

In addition, the button to Find a Table now has a minor color change on click.